### PR TITLE
Update tiny-eventemitter.js

### DIFF
--- a/src/tiny-eventemitter.js
+++ b/src/tiny-eventemitter.js
@@ -1,5 +1,5 @@
 angular.module('rt.eventemitter', []).factory('eventEmitter', function () {
-    var key = '_listeners';
+    var key = '$$listeners';
 
     function on($scope, event, fn) {
         if (typeof $scope === 'string') {


### PR DESCRIPTION
Use angulars '$$' prefix for internal listeners property. Some directives (e.g. ngRepeat) and filters (e.g. json) will and should ignore that property.
